### PR TITLE
fix: set preInitPlayer=true in Utils.isHarmony to resolve black screen

### DIFF
--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -394,7 +394,7 @@ class PlPlayerController {
   );
 
   late final horizontalSeasonPanel = Pref.horizontalSeasonPanel;
-  late final preInitPlayer = Pref.preInitPlayer;
+  late final preInitPlayer = Utils.isHarmony ? true : Pref.preInitPlayer;
   late final showRelatedVideo = Pref.showRelatedVideo;
   late final showVideoReply = Pref.showVideoReply;
   late final showBangumiReply = Pref.showBangumiReply;


### PR DESCRIPTION
鸿蒙默认初始化播放器解决黑屏bug