### PR TITLE
fix(ohos): prevent scaling loop when entering video page

### DIFF
--- a/lib/harmony_adapt/harmony_channel.dart
+++ b/lib/harmony_adapt/harmony_channel.dart
@@ -33,15 +33,25 @@ abstract class HarmonyChannel {
     _isFloatingWindow = isFloatingWindow;
     if (!isFloatingWindow) {
       ScalableWidgetsFlutterBinding.ensureInitialized().setScale(1);
-    } else if (_miniWindowLandscape) {
-      ScalableWidgetsFlutterBinding.ensureInitialized().setScale(
-        _miniWindowLandscapeScale,
-      );
+    } else {
+      if (_miniWindowLandscape) {
+        ScalableWidgetsFlutterBinding.ensureInitialized().setScale(
+          _miniWindowLandscapeScale,
+        );
+        _channel.invokeMethod('setMiniWindowLandscape', {
+          'landscape': true,
+        });
+      } else {
+        _channel.invokeMethod('setMiniWindowLandscape', {
+          'landscape': false,
+        });
+      }
     }
   }
 
   /// 设置小窗横屏
   static Future<bool> setMiniWindowLandscape(bool landscape) async {
+    _miniWindowLandscape = landscape;
     if (!landscape) {
       ScalableWidgetsFlutterBinding.ensureInitialized().setScale(1);
     } else if (_isFloatingWindow) {
@@ -49,13 +59,16 @@ abstract class HarmonyChannel {
         _miniWindowLandscapeScale,
       );
     }
-    final result = await _channel.invokeMethod<bool>('setMiniWindowLandscape', {
-      'landscape': landscape,
-    });
-    if (result == true) {
-      _miniWindowLandscape = landscape;
-      return true;
+    if (_isFloatingWindow) {
+      final result = await _channel.invokeMethod<bool>(
+        'setMiniWindowLandscape',
+        {'landscape': landscape},
+      );
+      if (result == true) {
+        return true;
+      }
+      return false;
     }
-    return false;
+    return true;
   }
 }


### PR DESCRIPTION
修复了进入视频详情页时，界面布局在 1.0 和 0.75 缩放比例之间反复跳动的问题。
- 优化 `setMiniWindowLandscape`：仅在当前处于悬浮窗模式时才调用原生方法，避免在全屏模式下触发不必要的窗口状态更新。
- 优化 `_onFloatingWindowChange`：在进入悬浮窗模式时，自动根据当前设置同步原生的横屏/竖屏状态。