### PR TITLE
fix(harmony volume): 视频页全程隐藏系统音量面板，仅显示应用内音量组件

### DIFF
--- a/lib/pages/video/widgets/player_focus.dart
+++ b/lib/pages/video/widgets/player_focus.dart
@@ -78,7 +78,6 @@ class PlayerFocus extends StatelessWidget {
           );
       }
     } else if (event is KeyUpEvent) {
-      if (PlatformUtils.isHarmony) plPlayerController.volumeUpdated();
       if (plPlayerController.longPressTimer?.tick == 0 && hasPlayer) {
         _setVolume(isIncrease: isIncrease);
       }

--- a/lib/plugin/pl_player/view.dart
+++ b/lib/plugin/pl_player/view.dart
@@ -205,7 +205,7 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
             if (mounted &&
                 !plPlayerController.volumeInterceptEventStream.value) {
               plPlayerController.volume.value = value;
-              if (Platform.isIOS && !FlutterVolumeController.showSystemUI) {
+              if (Platform.isIOS && !FlutterVolumeController.showSystemUI || PlatformUtils.isHarmony) {
                 plPlayerController
                   ..volumeIndicator.value = true
                   ..volumeTimer?.cancel()


### PR DESCRIPTION
在视频页播放时，无论是手势滑动还是按音量键调节音量，都只显示应用内的音量百分比组件，不再显示系统音量面板。 #51 